### PR TITLE
Use forward slashes in assembler code to make it compile on Linux too

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/devcontainers/cpp:debian
 
-# Install additional tools
+# Install additional tools including Java
 RUN apt-get update && apt-get -y install --no-install-recommends \
     cmake \
     build-essential \
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get -y install --no-install-recommends \
     clang \
     lldb \
     llvm \
+    default-jdk \
     && apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*

--- a/SIDPlayers/RaistlinBars/RaistlinBars.asm
+++ b/SIDPlayers/RaistlinBars/RaistlinBars.asm
@@ -931,8 +931,8 @@ PreDemoSetup:
 //; =============================================================================
 //; Include necessary system files
 //; =============================================================================
-.import source "..\INC\NMIFix.asm"
-.import source "..\INC\RasterLineTiming.asm"
+.import source "../INC/NMIFix.asm"
+.import source "../INC/RasterLineTiming.asm"
 
 EndCodeSegment:
 

--- a/SIDPlayers/RaistlinBarsADSR/RaistlinBarsADSR.asm
+++ b/SIDPlayers/RaistlinBarsADSR/RaistlinBarsADSR.asm
@@ -1595,8 +1595,8 @@ PreDemoSetup:
 //; =============================================================================
 //; Include necessary system files
 //; =============================================================================
-.import source "..\INC\NMIFix.asm"
-.import source "..\INC\RasterLineTiming.asm"
+.import source "../INC/NMIFix.asm"
+.import source "../INC/RasterLineTiming.asm"
 
 EndCodeSegment:
 

--- a/SIDPlayers/SimpleBitmap/SimpleBitmap.asm
+++ b/SIDPlayers/SimpleBitmap/SimpleBitmap.asm
@@ -114,8 +114,8 @@ JustPlayMusic:
     asl $d019
     rti
 
-.import source "..\INC\NMIFix.asm"
-.import source "..\INC\RasterLineTiming.asm"
+.import source "../INC/NMIFix.asm"
+.import source "../INC/RasterLineTiming.asm"
 
 * = BitmapMAPData "Bitmap MAP"
 	.fill BitmapMAPFile.getSize(), BitmapMAPFile.get(i)

--- a/SIDPlayers/SimpleRaster/SimpleRaster.asm
+++ b/SIDPlayers/SimpleRaster/SimpleRaster.asm
@@ -85,5 +85,5 @@ JustPlayMusic:
     asl $d019
     rti
 
-.import source "..\INC\NMIFix.asm"
-.import source "..\INC\RasterLineTiming.asm"
+.import source "../INC/NMIFix.asm"
+.import source "../INC/RasterLineTiming.asm"


### PR DESCRIPTION
I'm not 100% certain this works under Windows, because I haven't tested it, but I *think* it does, given that I successfully use forward slashes in KickAsm code under Windows in other projects.

This PR also contains https://github.com/RobertTroughton/SIDBlaster/pull/2, so if this is merged, that will get merged/closed too.